### PR TITLE
feat(EDD-5827): rollback init methods

### DIFF
--- a/huawei_push_kit_python/__init__.py
+++ b/huawei_push_kit_python/__init__.py
@@ -1,3 +1,4 @@
+from python37.src.push_admin import get_app, initialize_app
 from python37.src.push_admin.messaging import (
     ApiCallError,
     Message,
@@ -14,4 +15,6 @@ __all__ = [
     "send_message",
     "subscribe_topic",
     "unsubscribe_topic",
+    "get_app",
+    "initialize_app",
 ]

--- a/huawei_push_kit_python/__init__.py
+++ b/huawei_push_kit_python/__init__.py
@@ -1,5 +1,6 @@
 from python37.src.push_admin import get_app, initialize_app
 from python37.src.push_admin.messaging import (
+    AndroidConfig,
     ApiCallError,
     Message,
     TopicSubscribeResponse,
@@ -17,4 +18,5 @@ __all__ = [
     "unsubscribe_topic",
     "get_app",
     "initialize_app",
+    "AndroidConfig",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "huawei_push_kit_python"
 description = ""
-version = "v1.0.0"
+version = "v1.0.1"
 authors = ["Huawei"]
 maintainers = ["Nicolás Villalobos"]
 packages = [

--- a/python37/src/push_admin/__init__.py
+++ b/python37/src/push_admin/__init__.py
@@ -1,0 +1,72 @@
+# -*-coding:utf-8-*-
+#
+# Copyright 2020. Huawei Technologies Co., Ltd. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Huawei Admin SDK for Python."""
+
+import threading
+
+from python37.src.push_admin import _app
+
+_apps = {}
+_apps_lock = threading.RLock()
+_DEFAULT_APP_NAME = 'DEFAULT'
+
+
+def initialize_app(appid_at, appsecret_at, appid_push=None, token_server='https://oauth-login.cloud.huawei.com/oauth2/v3/token',
+                   push_open_url='https://push-api.cloud.huawei.com'):
+    """
+        Initializes and returns a new App instance.
+        :param appid_at: appid parameters obtained by developer alliance applying for Push service
+        :param appsecret_at: appsecret parameters obtained by developer alliance applying for Push service
+        :param appid_push: the application Id in the URL
+        :param token_server: Oauth server URL
+        :param push_open_url: push open API URL
+    """
+    app = _app.App(appid_at, appsecret_at, appid_push, token_server=token_server, push_open_url=push_open_url)
+
+    with _apps_lock:
+        if appid_at not in _apps:
+            _apps[appid_at] = app
+
+        """set default app instance"""
+        if _apps.get(_DEFAULT_APP_NAME) is None:
+            _apps[_DEFAULT_APP_NAME] = app
+
+
+def get_app(appid=None):
+    """
+        get app instance
+        :param appid: appid parameters obtained by developer alliance applying for Push service
+        :return: app instance
+        Raise: ValueError
+    """
+    if appid is None:
+        with _apps_lock:
+            app = _apps.get(_DEFAULT_APP_NAME)
+            if app is None:
+                raise ValueError('The default Huawei app is not exists. '
+                                 'This means you need to call initialize_app() it.')
+            return app
+
+    with _apps_lock:
+        if appid not in _apps:
+            raise ValueError('Huawei app id[{0}] is not exists. '
+                             'This means you need to call initialize_app() it.'.format(appid))
+
+        app = _apps.get(appid)
+        if app is None:
+            raise ValueError('The app id[{0}] is None.'.format(appid))
+        return app


### PR DESCRIPTION
Se exponen métodos faltantes a pedido del equipo de server, se deja abierto este PR hasta que server apruebe el funcionamiento completo para sacar un nuevo tag.